### PR TITLE
Robust catchup-subscription re-implementation

### DIFF
--- a/src/internal/connection.rs
+++ b/src/internal/connection.rs
@@ -130,7 +130,7 @@ impl Encoder for PkgCodec {
             }
         };
 
-        dst.put_u32::<LittleEndian>(size as u32);
+        dst.put_u32_le(size as u32);
         dst.put_u8(item.cmd.to_u8());
         dst.put_u8(auth_flag);
         dst.put_slice(item.correlation.as_bytes());

--- a/src/internal/registry.rs
+++ b/src/internal/registry.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 use bytes::BytesMut;
 use uuid::Uuid;
 
+use internal::command::Cmd;
 use internal::connection::Connection;
-use internal::operations::{ OperationError, OperationWrapper, OperationId, Outcome };
+use internal::operations::{ OperationError, OperationWrapper, OperationId, Tracking, Session };
 use internal::package::Pkg;
 
 struct Checking {
@@ -28,128 +29,228 @@ impl Checking {
     }
 }
 
-struct Session {
-    op: OperationWrapper,
+struct Request {
+    session: OperationId,
+    conn_id: Uuid,
+    tracker: Tracking,
 }
 
-impl Session {
-    fn new(op: OperationWrapper) -> Session {
-        Session {
-            op,
+impl Request {
+    fn new(session: OperationId, cmd: Cmd, conn_id: Uuid) -> Request {
+        Request {
+            session,
+            conn_id,
+            tracker: Tracking::new(cmd),
         }
     }
 
-    fn issue_requests(&mut self, buffer: &mut BytesMut) -> ::std::io::Result<Vec<Pkg>> {
-        self.op.poll(buffer, None).map(|outcome| outcome.produced_pkgs())
-    }
-
-    fn report_error(&mut self, error: OperationError) {
-        self.op.failed(error);
-    }
-
-    fn accept_pkg(&mut self, buffer: &mut BytesMut, pkg: Pkg) -> ::std::io::Result<Outcome> {
-        self.op.poll(buffer, Some(pkg))
+    fn get_id(&self) -> Uuid {
+        self.tracker.get_id()
     }
 }
 
-type SessionAssocs = HashMap<OperationId, Session>;
-type Requests      = HashMap<Uuid, Request>;
+struct SessionImpl<'a> {
+    id: OperationId,
+    assocs: &'a mut HashMap<Uuid, Request>,
+    conn: &'a Connection,
+    runnings: &'a mut Vec<Uuid>,
+}
 
-struct Sessions {
+impl<'a> SessionImpl<'a> {
+    fn new(
+        id: OperationId,
+        assocs: &'a mut HashMap<Uuid, Request>,
+        conn: &'a Connection,
+        runnings: &'a mut Vec<Uuid>) -> SessionImpl<'a>
+    {
+        SessionImpl {
+            id,
+            assocs,
+            conn,
+            runnings,
+        }
+    }
+}
+
+fn terminate(assocs: &mut HashMap<Uuid, Request>, runnings: Vec<Uuid>) {
+    for id in runnings {
+        assocs.remove(&id);
+    }
+}
+
+impl<'a> Session for SessionImpl<'a> {
+    fn new_request(&mut self, cmd: Cmd) -> Uuid {
+        let req = Request::new(self.id, cmd, self.conn.id);
+        let id  = req.get_id();
+
+        self.assocs.insert(id, req);
+        self.runnings.push(id);
+
+        id
+    }
+
+    fn pop(&mut self, id: &Uuid) -> ::std::io::Result<Tracking> {
+        match self.assocs.remove(id) {
+            Some(req) => {
+                let pos = self.runnings
+                              .iter()
+                              .position(|x| x == id).unwrap();
+
+                self.runnings.remove(pos);
+
+                Ok(req.tracker)
+            },
+
+            None => {
+                let error = ::std::io::Error::new(::std::io::ErrorKind::Other, "Tracker must exists");
+                Err(error)
+            },
+        }
+    }
+
+    fn reuse(&mut self, tracker: Tracking) {
+        let id  = tracker.get_id();
+        let req = Request {
+            session: self.id,
+            conn_id: self.conn.id,
+            tracker,
+        };
+
+        self.runnings.push(id);
+        self.assocs.insert(id, req);
+    }
+
+    fn using(&mut self, id: &Uuid) -> ::std::io::Result<&mut Tracking> {
+        match self.assocs.get_mut(id) {
+            Some(req) => Ok(&mut req.tracker),
+            None      => {
+                let error = ::std::io::Error::new(::std::io::ErrorKind::Other, "Tracker must exists");
+                Err(error)
+            },
+        }
+    }
+
+    fn requests(&self) -> Vec<&Tracking> {
+        self.assocs.values().map(|req| &req.tracker).collect()
+    }
+
+    fn terminate(&mut self) {
+        terminate(self.assocs, self.runnings.drain(..).collect());
+    }
+}
+
+struct Requests {
+    sessions: HashMap<OperationId, OperationWrapper>,
+    session_request_ids: HashMap<OperationId, Vec<Uuid>>,
+    assocs: HashMap<Uuid, Request>,
     buffer: BytesMut,
-    assocs: SessionAssocs,
-    requests: Requests,
 }
 
-impl Sessions {
-    fn new() -> Sessions {
-        Sessions {
-            buffer: BytesMut::new(),
+impl Requests {
+    fn new() -> Requests {
+        Requests {
+            sessions: HashMap::new(),
+            session_request_ids: HashMap::new(),
             assocs: HashMap::new(),
-            requests: HashMap::new(),
+            buffer: BytesMut::new(),
         }
     }
 
-    fn insert_session(&mut self, session: Session) {
-        self.assocs.insert(session.op.id, session);
-    }
+    fn register(&mut self, conn: &Connection, mut op: OperationWrapper) {
+        let mut runnings = Vec::new();
+        let     success = {
+            let session = SessionImpl::new(op.id, &mut self.assocs, conn, &mut runnings);
 
-    fn send_pkgs(requests: &mut Requests, session: &mut Session, conn: &Connection, pkgs: Vec<Pkg>) {
-        for pkg in &pkgs {
-            let req = Request::new(session.op.id, conn);
+            match op.send(&mut self.buffer, session).map(|out| out.produced_pkgs()) {
+                Ok(pkgs) => {
+                    conn.enqueue_all(pkgs);
 
-            requests.insert(pkg.correlation, req);
-            debug!("Request issued: {} cmd: {:?}", pkg.correlation, pkg.cmd);
+                    true
+                },
+
+                Err(e) => {
+                    error!("Exception occured when issuing requests: {}", e);
+
+                    false
+                },
+            }
+        };
+
+        if !success {
+            terminate(&mut self.assocs, runnings);
+        } else {
+            self.session_request_ids.insert(op.id, runnings);
+            self.sessions.insert(op.id, op);
         }
-
-        conn.enqueue_all(pkgs)
     }
 
-    fn get_session_mut<'a>(assocs: &'a mut SessionAssocs, session_id: &OperationId) -> &'a mut Session {
-        assocs.get_mut(session_id).expect("Session must be defined at this point")
-    }
-
-    fn handle_request_response(&mut self, pkg: Pkg, conn: &Connection) {
+    fn handle_pkg(&mut self, conn: &Connection, pkg: Pkg) {
         let pkg_id  = pkg.correlation;
         let pkg_cmd = pkg.cmd;
 
-        if let Some(req) = self.requests.remove(&pkg.correlation) {
+        if let Some(req) = self.assocs.remove(&pkg_id) {
             debug!("Package [{}] received: command {:?}.", pkg_id, pkg_cmd.to_u8());
 
-            let session_id = req.session;
-            let session_completed = {
-                let session = Sessions::get_session_mut(&mut self.assocs, &session_id);
+            let session_id   = req.session;
+            let session_over = {
+                let runnings = self.session_request_ids
+                                   .get_mut(&req.session)
+                                   .expect("No session associated to request!");
 
-                // We notified the operation we've received a 'Pkg' from the server
-                // that might interest it.
-                match session.accept_pkg(&mut self.buffer, pkg) {
-                    Ok(outcome) => {
-                        if outcome.is_continuing() {
+                let op = self.sessions
+                             .get_mut(&session_id)
+                             .expect("Unknown session!");
+
+                // We insert back the request to let the operation decides if it
+                // want to keep it.
+                self.assocs.insert(pkg_id, req);
+
+                let errored = {
+                    let session =
+                        SessionImpl::new(
+                            session_id, &mut self.assocs, conn, runnings);
+
+                    match op.receive(&mut self.buffer, session, pkg) {
+                        Ok(outcome) => {
                             let pkgs = outcome.produced_pkgs();
 
-                            if pkgs.is_empty() {
-                                debug!("Operation is continuing on id: {}", pkg_id);
-                                // This operation wants to keep its old correlation
-                                // id, so we insert the request back.
-                                self.requests.insert(pkg_id, req);
-                            } else {
-                                debug!("Operation has been terminated on id: {}, cmd: {:?}", pkg_id, pkg_cmd);
-                                // This operation issued a new transaction requests
-                                // with the server,
-                                Sessions::send_pkgs(&mut self.requests, session, conn, pkgs);
+                            if !pkgs.is_empty() {
+                                conn.enqueue_all(pkgs);
                             }
-                        }
-                    },
 
-                    Err(e) => {
-                        let msg = format!("Exception raised: {}", e);
+                            None
+                        },
 
-                        session.report_error(OperationError::InvalidOperation(msg));
-                    },
+                        Err(e) => {
+                            error!("An error occured when running operation: {}", e);
+                            let msg = format!("Exception raised: {}", e);
+
+                            Some(msg)
+                        },
+                    }
                 };
 
-                session.op.is_completed()
+                if let Some(msg) = errored {
+                    op.failed(OperationError::InvalidOperation(msg));
+                    terminate(&mut self.assocs, runnings.drain(..).collect());
+                }
+
+                runnings.is_empty()
             };
 
-            if session_completed {
-                debug!("Session related to {} has been closed", pkg_id);
-                // The given operation has no longer opened requests, so we can
-                // drop it safely.
-                let _ = self.assocs.remove(&session_id);
+            if session_over {
+                self.sessions.remove(&session_id);
+                self.session_request_ids.remove(&session_id);
             }
         } else {
             warn!("Package [{}] not handled: cmd {:?}.", pkg_id, pkg_cmd);
         }
     }
 
-    fn terminate_session(&mut self, session: &mut Session) {
-        session.report_error(OperationError::Aborted);
-    }
-
     fn check_and_retry(&mut self, conn: &Connection) {
         let mut process_later = Vec::new();
 
-        for (key, req) in &self.requests {
+        for (key, req) in &self.assocs {
             if req.conn_id != conn.id {
                 process_later.push(Checking::delete(*key));
             } else {
@@ -158,108 +259,99 @@ impl Sessions {
         }
 
         for status in process_later {
-            if let Some(mut req) = self.requests.remove(&status.key) {
+            if let Some(mut req) = self.assocs.remove(&status.key) {
+
                 if status.is_checking {
-                    let delete_session = {
-                        let session = Sessions::get_session_mut(&mut self.assocs, &req.session);
-                        match session.op.check_and_retry(&mut self.buffer) {
+                    let terminated_requests = {
+                        let op = self.sessions
+                                     .get_mut(&req.session)
+                                     .expect("No session associated to request");
+
+                        let runnings = self.session_request_ids
+                                           .get_mut(&req.session)
+                                           .expect("No session attached to request");
+
+                        let result = {
+                            let session =
+                                SessionImpl::new(
+                                    req.session, &mut self.assocs, conn, runnings);
+
+                            op.check_and_retry(&mut self.buffer, session)
+                        };
+
+                        match result {
                             Ok(outcome) => {
                                 if outcome.is_done() {
-                                    Some(req.session)
+                                    runnings.drain(..).collect()
                                 } else {
                                     let pkgs = outcome.produced_pkgs();
 
-                                    if pkgs.is_empty() {
-                                        self.requests.insert(status.key, req);
-                                    } else {
-                                        Sessions::send_pkgs(&mut self.requests, session, conn, pkgs);
+                                    if !pkgs.is_empty() {
+                                        conn.enqueue_all(pkgs);
                                     }
 
-                                    None
+                                    Vec::new()
                                 }
                             },
 
                             Err(e) => {
                                 error!("Exception raised when checking out operation: {}", e);
-                                Some(req.session)
+                                let msg = format!("Exception raised: {}", e);
+
+                                op.failed(OperationError::InvalidOperation(msg));
+                                runnings.drain(..).collect()
                             },
                         }
                     };
 
-                    if let Some(session_id) = delete_session {
-                        let mut session = self.assocs.remove(&session_id).expect("Session must exist.");
-                        self.terminate_session(&mut session);
+                    if !terminated_requests.is_empty() {
+                        terminate(&mut self.assocs, terminated_requests);
+                        self.sessions.remove(&req.session);
+                        self.session_request_ids.remove(&req.session);
                     }
                 } else {
-                    let mut session = self.assocs.remove(&req.session).expect("Session must exist.");
+                    let mut op = self.sessions
+                                     .remove(&req.session)
+                                     .expect("No session associated with request!");
 
-                    self.terminate_session(&mut session);
+                    let runnings = self.session_request_ids
+                                       .remove(&req.session)
+                                       .expect("No session attached to request");
+
+                    op.failed(OperationError::Aborted);
+                    terminate(&mut self.assocs, runnings);
                 }
             }
         }
     }
 }
 
-struct Request {
-    session: OperationId,
-    conn_id: Uuid,
-}
-
-impl Request {
-    fn new(session: OperationId, conn: &Connection) -> Request {
-        Request {
-            session,
-            conn_id: conn.id,
-        }
-    }
-}
-
 pub(crate) struct Registry {
-    sessions: Sessions,
+    requests: Requests,
     awaiting: Vec<OperationWrapper>,
 }
 
 impl Registry {
     pub(crate) fn new() -> Registry {
         Registry {
-            sessions: Sessions::new(),
+            requests: Requests::new(),
             awaiting: Vec::new(),
         }
-    }
-
-    fn push_session(&mut self, op: OperationWrapper, conn: &Connection) {
-        let mut session = Session::new(op);
-
-        match session.issue_requests(&mut self.sessions.buffer) {
-            Ok(pkgs) => {
-                Sessions::send_pkgs(&mut self.sessions.requests, &mut session, conn, pkgs);
-
-                self.sessions.insert_session(session);
-            },
-
-            Err(e) => {
-                // Don't need to cleanup the session at this stage
-                // because the session never got the chance to be
-                // inserted in the session maps and having running
-                // requests.
-                error!("Exception occured when issuing requests: {}", e);
-            },
-        };
     }
 
     pub(crate) fn register(&mut self, op: OperationWrapper, conn: Option<&Connection>) {
         match conn {
             None       => self.awaiting.push(op),
-            Some(conn) => self.push_session(op, conn),
+            Some(conn) => self.requests.register(conn, op),
         }
     }
 
     pub(crate) fn handle(&mut self, pkg: Pkg, conn: &Connection) {
-        self.sessions.handle_request_response(pkg, conn);
+        self.requests.handle_pkg(conn, pkg);
     }
 
     pub(crate) fn check_and_retry(&mut self, conn: &Connection) {
-        self.sessions.check_and_retry(conn);
+        self.requests.check_and_retry(conn);
 
         while let Some(op) = self.awaiting.pop() {
             self.register(op, Some(conn));

--- a/src/internal/timespan.rs
+++ b/src/internal/timespan.rs
@@ -67,6 +67,12 @@ impl Builder {
     }
 }
 
+// Using `Duration::subsec_millis` forces nigthly rustc usage at this time.
+// This function will be deleted once `Duration::subsec_millis` lands on
+// stable.
+const NANOS_PER_MILLI: u32 = 1_000_000;
+fn duration_subsec_millis(duration: &Duration) -> u32 { duration.subsec_nanos() / NANOS_PER_MILLI }
+
 impl Timespan {
     fn from_ticks(ticks: u64) -> Timespan {
         Timespan {
@@ -78,7 +84,7 @@ impl Timespan {
         let mut builder = Timespan::builder();
 
         builder.seconds(duration.as_secs())
-               .milliseconds(duration.subsec_millis() as u64)
+               .milliseconds(duration_subsec_millis(&duration) as u64)
                .build()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(duration_extras)]
+// #![feature(duration_extras)]
 
 extern crate core;
 extern crate bytes;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -307,5 +307,5 @@ fn all_round_operation_test() {
     test_read_all_stream(&client);
     test_delete_stream(&client);
     test_volatile_subscription(&client);
-//  test_catchup_subscription(&client);
+    test_catchup_subscription(&client);
 }


### PR DESCRIPTION
I figured out a better implementation a week ago for catchup subscription and also overall internal operation API. With this new operation API, an operation can send multiple exchanges to the server at the same time. Why? Because it makes catchup subscription easier to implement, especially when dealing with runtime exception like connection drops and timeouts. This implementation is very similar to my Haskell implementation. The only difference is in the Rust version, an operation can send multiple packages to the server (starting 2 or more commands at the same time for instance) while a Haskell operation can only do it one package at the time.

However, in Haskell, I was able to encode safely most state-machine transitions in the type-system. In Rust, all the safety checks are done during runtime. Good news though, this Rust implementation is way faster and require less memory.