### PR TITLE
Don't panic on second call if server is off

### DIFF
--- a/src/internal/operations.rs
+++ b/src/internal/operations.rs
@@ -179,7 +179,9 @@ impl WriteEvents {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -289,7 +291,9 @@ impl ReadEvent {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -409,7 +413,9 @@ impl TransactionStart {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -535,7 +541,9 @@ impl TransactionWrite {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -663,7 +671,9 @@ impl TransactionCommit {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -811,7 +821,9 @@ impl ReadStreamEvents {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -936,7 +948,9 @@ impl ReadAllEvents {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -1063,7 +1077,9 @@ impl DeleteStream {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -1864,7 +1880,9 @@ impl CreatePersistentSubscription {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -1972,7 +1990,9 @@ impl UpdatePersistentSubscription {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -2053,7 +2073,9 @@ impl DeletePersistentSubscription {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
+        promise
+            .await
+            .map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 

--- a/src/internal/operations.rs
+++ b/src/internal/operations.rs
@@ -179,7 +179,7 @@ impl WriteEvents {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 
@@ -289,7 +289,7 @@ impl ReadEvent {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 
@@ -409,7 +409,7 @@ impl TransactionStart {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 
@@ -535,7 +535,7 @@ impl TransactionWrite {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 
@@ -663,7 +663,7 @@ impl TransactionCommit {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 
@@ -811,7 +811,7 @@ impl ReadStreamEvents {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 
@@ -936,7 +936,7 @@ impl ReadAllEvents {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 
@@ -1063,7 +1063,7 @@ impl DeleteStream {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 
@@ -1864,7 +1864,7 @@ impl CreatePersistentSubscription {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 
@@ -1972,7 +1972,7 @@ impl UpdatePersistentSubscription {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 
@@ -2053,7 +2053,7 @@ impl DeletePersistentSubscription {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.unwrap()
+        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
     }
 }
 

--- a/src/internal/operations.rs
+++ b/src/internal/operations.rs
@@ -179,7 +179,7 @@ impl WriteEvents {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -289,7 +289,7 @@ impl ReadEvent {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -409,7 +409,7 @@ impl TransactionStart {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -535,7 +535,7 @@ impl TransactionWrite {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -663,7 +663,7 @@ impl TransactionCommit {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -811,7 +811,7 @@ impl ReadStreamEvents {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -936,7 +936,7 @@ impl ReadAllEvents {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -1063,7 +1063,7 @@ impl DeleteStream {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -1864,7 +1864,7 @@ impl CreatePersistentSubscription {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -1972,7 +1972,7 @@ impl UpdatePersistentSubscription {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 
@@ -2053,7 +2053,7 @@ impl DeletePersistentSubscription {
             Ok(()) as std::io::Result<()>
         });
 
-        promise.await.map_err(|_| types::OperationError::ConnectionHasDropped)?
+        promise.await.map_err(|_| types::OperationError::ConnectionClosed)?
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,6 +35,7 @@ pub enum OperationError {
     WrongClientImpl(Option<Cmd>),
     ConnectionHasDropped,
     NotImplemented,
+    ConnectionClosed,
 }
 
 impl std::error::Error for OperationError {}
@@ -59,6 +60,7 @@ impl std::fmt::Display for OperationError {
             WrongClientImpl(info) => writeln!(f, "wrong client impl: {:?}", info),
             ConnectionHasDropped => writeln!(f, "connection has dropped"),
             NotImplemented => writeln!(f, "not implemented"),
+            ConnectionClosed => writeln!(f, "connection closed"),
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,7 +11,7 @@ fn fresh_stream_id(prefix: &str) -> String {
 
 pub mod tcp {
     use super::fresh_stream_id;
-    use eventstore::Slice;
+    use eventstore::{Slice, Retry};
     use futures::channel::oneshot;
     use futures::SinkExt;
     use std::collections::HashMap;
@@ -646,6 +646,33 @@ pub mod tcp {
             Ok(()) as Result<(), Box<dyn Error>>
         })
         .unwrap();
+    }
+
+    #[test]
+    fn offline_server_test() {
+        block_on(async {
+            let host = std::env::var("EVENTSTORE_HOST").unwrap_or("127.0.0.1".to_string());
+            let conn_str = format!("{}:1114", host); // Be sure your server doesn't run on port 1114
+
+            info!("Connection string: {}", conn_str);
+
+            let endpoint = conn_str.to_socket_addrs().unwrap().next().unwrap();
+
+            let connection = eventstore::Connection::builder()
+                .connection_retry(Retry::Only(0))
+                .with_default_user(eventstore::Credentials::new("admin", "changeit"))
+                .single_node_connection(endpoint)
+                .await;
+
+            let stream_id = fresh_stream_id("stream-id");
+            let group_name = "group-name";
+
+            assert!(connection.read_all().execute().await.is_err());
+            assert!(connection.read_all().execute().await.is_err());
+            assert!(connection.read_event(stream_id.as_str(), 0).execute().await.is_err());
+            assert!(connection.read_stream(stream_id.as_str()).execute().await.is_err());
+            assert!(connection.create_persistent_subscription(stream_id.as_str(), group_name).execute().await.is_err());
+        });
     }
 }
 #[cfg(feature = "es6")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,7 +11,7 @@ fn fresh_stream_id(prefix: &str) -> String {
 
 pub mod tcp {
     use super::fresh_stream_id;
-    use eventstore::{Slice, Retry};
+    use eventstore::{Retry, Slice};
     use futures::channel::oneshot;
     use futures::SinkExt;
     use std::collections::HashMap;
@@ -670,9 +670,21 @@ pub mod tcp {
 
             assert!(connection.read_all().execute().await.is_err());
             assert!(connection.read_all().execute().await.is_err());
-            assert!(connection.read_event(stream_id.as_str(), 0).execute().await.is_err());
-            assert!(connection.read_stream(stream_id.as_str()).execute().await.is_err());
-            assert!(connection.create_persistent_subscription(stream_id.as_str(), group_name).execute().await.is_err());
+            assert!(connection
+                .read_event(stream_id.as_str(), 0)
+                .execute()
+                .await
+                .is_err());
+            assert!(connection
+                .read_stream(stream_id.as_str())
+                .execute()
+                .await
+                .is_err());
+            assert!(connection
+                .create_persistent_subscription(stream_id.as_str(), group_name)
+                .execute()
+                .await
+                .is_err());
         });
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -659,6 +659,7 @@ pub mod tcp {
             let endpoint = conn_str.to_socket_addrs().unwrap().next().unwrap();
 
             let connection = eventstore::Connection::builder()
+                .connection_timeout(Duration::from_secs(0))
                 .connection_retry(Retry::Only(0))
                 .with_default_user(eventstore::Credentials::new("admin", "changeit"))
                 .single_node_connection(endpoint)


### PR DESCRIPTION
Transform `oneshot::Canceled` errors to `OperationError::ConnectionHasDropped` and forward them to the caller so it can handle them properly.

Previous `.unwrap()` used to cause panicking when two operations was requested on a shutdown server.

Fix #52 

### Additional information

I don't know why, but I wasn't able to test writing operations. They were all blocking the test that couldn't finish, not even a panic :thinking: 
- `connection.write_events`
- `connection.start_transaction`
- `transaction.write`
- `transaction.commit`
- `connection.delete_stream`
- `connection.update_persistent_subscription`
- `connection.delete_persistent_subscription`

Also, the test `offline_server_test` I wrote displays this "error" :
```
ERROR eventstore::internal::driver] Maximum reconnection attempt count reached (0)!
```
I don't know if it's disturbing ?

Another detail, we can't change the `Driver::reconnect_delay` with the `ConnectionBuilder` API, which makes the test 3 seconds too long... :yum: 