### PR TITLE
derive Clone for connections

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -23,6 +23,7 @@ use crate::types::{self, GossipSeedClusterSettings, OperationError, Settings, St
 /// or a single thread can make many asynchronous requests. To get the most
 /// performance out of the connection, it is generally recommended to use it
 /// in this way.
+#[derive(Clone)]
 pub struct Connection {
     sender: Sender<Msg>,
 }

--- a/src/es6/connection.rs
+++ b/src/es6/connection.rs
@@ -33,6 +33,7 @@ impl rustls::ServerCertVerifier for NoVerification {
 /// or a single thread can make many asynchronous requests. To get the most
 /// performance out of the connection, it is generally recommended to use it
 /// in this way.
+#[derive(Clone)]
 pub struct Connection {
     settings: Settings,
     streams: streams::streams_client::StreamsClient<Channel>,


### PR DESCRIPTION
It is still recommended to wrap Connections in a std::sync::Arc, but for certain uses cases, it may be convenient to clone directly.  One use case currently is actix-web's data internally wraps with Arc, so a direct clone could prevent this behavior.  Reference: https://github.com/actix/actix-web/issues/1454