### PR TITLE
set tonic version to 0.2.2 and fix compilation of error propogation i…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ vec1 = "1.4"
 rand = "0.7"
 byteorder = { version = "1.2", optional = true }
 http = { version = "0.2", optional = true }
-tonic = { version = "0.2", features = ["tls", "tls-roots"], optional = true }
+tonic = { version = "0.2.2", features = ["tls", "tls-roots"], optional = true }
 prost = { version = "0.6", optional = true }
 prost-derive = { version = "0.6", optional = true }
 prost-types = { version = "0.6", optional = true }

--- a/src/es6/connection.rs
+++ b/src/es6/connection.rs
@@ -153,7 +153,7 @@ impl Connection {
             let client_config =
                 tonic::transport::ClientTlsConfig::new().rustls_client_config(rustls_config);
 
-            channel = channel.tls_config(client_config);
+            channel = channel.tls_config(client_config)?;
         }
 
         let channel = channel.connect().await?;


### PR DESCRIPTION
Tonic broke some channel API's in a recent release from 0.2.1 to 0.2.2 https://github.com/hyperium/tonic/commit/3b9d6a6262b62f30b8c9953f0da8e403be53216e

New users of using the es6 feature will resolve to the newest 0.2.2 due to semver rules for ```tonic = 0.2``` in cargo.toml.  This PR sets the minimum version of to 0.2.2 and fixes compilation issues.